### PR TITLE
Set s3 bucket name prefixes, update deprecated config directives

### DIFF
--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -2,12 +2,17 @@
 # AWS PROVIDER FOR TF CLOUD
 # ---------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
   backend "s3" {
     # Setting variables in the backend section isn't possible as of now, see https://github.com/hashicorp/terraform/issues/13022
-    bucket_prefix = "terraform-backend-state-cc-cloud-bootstrap"
+    bucket = "tf-backend-state-cc-cloud-bootstrap"
     encrypt = true
-    dynamodb_table = "terraform-backend-lock-cc-cloud-bootstrap"
+    dynamodb_table = "tf-backend-lock-cc-cloud-bootstrap"
     key = "terraform.tfstate"
     region = "eu-central-1"
   }

--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_version = ">1.0.0"
   backend "s3" {
     # Setting variables in the backend section isn't possible as of now, see https://github.com/hashicorp/terraform/issues/13022
-    bucket = "terraform-backend-state-cc-cloud-bootstrap"
+    bucket_prefix = "terraform-backend-state-cc-cloud-bootstrap"
     encrypt = true
     dynamodb_table = "terraform-backend-lock-cc-cloud-bootstrap"
     key = "terraform.tfstate"

--- a/terraform/remote-state/main.tf
+++ b/terraform/remote-state/main.tf
@@ -12,14 +12,22 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "terraform-backend-state" {
-  bucket = "terraform-backend-state-${var.project}"
-  acl = "private"
-  versioning {
-    enabled = true
-  }
+  bucket_prefix = "terraform-backend-state-${var.project}"
   tags = {
     Name = "${var.stack}-Terraform-Remote-State-S3"
     Project = var.project
+  }
+}
+
+resource "aws_s3_bucket_acl" "terraform-backend-state-acl" {
+  bucket = aws_s3_bucket.terraform-backend-state.id
+  acl = "private"
+}
+
+resource "aws_s3_bucket_versioning" "terraform-backend-state-versioning" {
+  bucket = aws_s3_bucket.terraform-backend-state.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/terraform/remote-state/main.tf
+++ b/terraform/remote-state/main.tf
@@ -3,7 +3,12 @@
 # Apply first before initializing any project resources
 # ---------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }
 
 provider "aws" {
@@ -12,7 +17,7 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "terraform-backend-state" {
-  bucket_prefix = "terraform-backend-state-${var.project}"
+  bucket_prefix = "tf-backend-state-${var.project}-"
   tags = {
     Name = "${var.stack}-Terraform-Remote-State-S3"
     Project = var.project
@@ -32,7 +37,7 @@ resource "aws_s3_bucket_versioning" "terraform-backend-state-versioning" {
 }
 
 resource "aws_dynamodb_table" "terraform-backend-lock" {
-  name = "terraform-backend-lock-${var.project}"
+  name = "tf-backend-lock-${var.project}"
   hash_key = "LockID"
   read_capacity = 5
   write_capacity = 5

--- a/terraform/remote-state/main.tf
+++ b/terraform/remote-state/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 }
 
 resource "aws_s3_bucket" "terraform-backend-state" {
-  bucket_prefix = "tf-backend-state-${var.project}-"
+  bucket = "tf-backend-state-${var.project}"
   tags = {
     Name = "${var.stack}-Terraform-Remote-State-S3"
     Project = var.project


### PR DESCRIPTION
This updates the aws provider to v4. Dropped using prefixed bucket names as variables cannot be used in the backend config block.